### PR TITLE
update(dfo): removed 10 working day warning

### DIFF
--- a/docs/en/dfo/management-review-process.md
+++ b/docs/en/dfo/management-review-process.md
@@ -27,10 +27,6 @@ Your role as the reviewing manager is to ensure that:
 1. The manuscript complies with the [Intellectual Property Policy/Copyright Act](https://www.dfo-mpo.gc.ca/terms-avis/copyright-droits-eng.htm), the [Privacy Act](https://www.priv.gc.ca/en/privacy-topics/privacy-laws-in-canada/the-privacy-act/pa_brief/), the Financial Administration Act (with respect to approvals of publication costs), and the [Values and Ethics Code for DFO](https://www.dfo-mpo.gc.ca/reports-rapports/vicr-virc/vicr-virc2012-eng.htm).
 2. The Regional Director of Science (RDS) and Regional DFO Communications are informed if the manuscript contains content with potential public interest.
 
-:::warning
-Science management commits to a 10-working-day turnaround for manuscript sign-off. If managers do not respond with
-approval within 10 working days, authors may submit their manuscript to the EOS Publication Team.
-:::
 
 ### Review the Manuscript Form
 

--- a/docs/fr/dfo/management-review-process.md
+++ b/docs/fr/dfo/management-review-process.md
@@ -26,9 +26,6 @@ Votre rôle en tant que gestionnaire examinateur est de vous assurer que :
 1. Le manuscrit est conforme à la [Politique sur la propriété intellectuelle/Loi sur le droit d’auteur](https://www.dfo-mpo.gc.ca/terms-avis/copyright-droits-fra.htm), à la [Loi sur la protection des renseignements personnels](https://www.priv.gc.ca/fr/sujets-lies-a-la-protection-de-la-vie-privee/lois-sur-la-protection-des-renseignements-personnels-au-canada/la-loi-sur-la-protection-des-renseignements-personnels/lprp_survol/), à la Loi sur la gestion des finances publiques (en ce qui concerne l’approbation des coûts de publication) et au [Code de valeurs et d’éthique du MPO](https://www.dfo-mpo.gc.ca/reports-rapports/vicr-virc/vicr-virc2012-fra.htm).
 2. Le directeur régional des sciences (DRS) et les Communications régionales du MPO sont informés si le manuscrit contient du contenu susceptible d’intéresser le public.
 
-:::warning
-La gestion des sciences s'engage à signer les manuscrits dans un délai de 10 jours ouvrables. Si les gestionnaires ne répondent pas avec une approbation dans ce délai, les auteurs peuvent soumettre leur manuscrit à l'équipe de publication de l'ÉSO.
-:::
 
 ### Examiner la fiche du manuscrit
 


### PR DESCRIPTION
### What
This PR applies content changes to the 10 working day turnaround for DFO publications.

### Content Change
- The "10 working day turnaround" warning element has been removed. 