### PR TITLE
bug(vue): added vue-route to fix build fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "esbuild": "^0.27.2",
     "markdown-it": "^14.1.0",
     "undici": "^7.16.0",
-    "vite": "^7.3.0"
+    "vite": "^7.3.0",
+    "vue-router": "^4.6.4"
   },
   "packageManager": "pnpm@10.26.2+sha512.0e308ff2005fc7410366f154f625f6631ab2b16b1d2e70238444dd6ae9d630a8482d92a451144debc492416896ed16f7b114a86ec68b8404b2443869e68ffda6"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     dependencies:
       '@vue/server-renderer':
         specifier: ^3.5.26
-        version: 3.5.26(vue@3.5.26)
+        version: 3.5.27(vue@3.5.27)
       '@vuepress/core':
         specifier: 2.0.0-rc.18
         version: 2.0.0-rc.18
       '@vuepress/plugin-copy-code':
         specifier: 2.0.0-rc.121
-        version: 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+        version: 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       '@vuepress/plugin-external-link-icon':
         specifier: 2.0.0-rc.0
         version: 2.0.0-rc.0
@@ -31,29 +31,32 @@ importers:
         version: 7.18.2
       vite:
         specifier: ^7.3.0
-        version: 7.3.1(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2)
+        version: 7.3.1(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2)
+      vue-router:
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.27)
     devDependencies:
       '@vuepress/bundler-vite':
         specifier: 2.0.0-rc.18
-        version: 2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2)
+        version: 2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2)
       '@vuepress/client':
         specifier: 2.0.0-rc.18
         version: 2.0.0-rc.18
       '@vuepress/plugin-search':
         specifier: 2.0.0-rc.121
-        version: 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+        version: 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       '@vuepress/theme-default':
         specifier: 2.0.0-rc.60
-        version: 2.0.0-rc.60(markdown-it@14.1.0)(sass-embedded@1.97.2)(sass@1.97.2)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+        version: 2.0.0-rc.60(markdown-it@14.1.0)(sass-embedded@1.97.2)(sass@1.97.2)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       sass-embedded:
         specifier: ^1.97.1
         version: 1.97.2
       vue:
         specifier: ^3.5.26
-        version: 3.5.26
+        version: 3.5.27
       vuepress:
         specifier: 2.0.0-rc.26
-        version: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+        version: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
 
 packages:
 
@@ -729,128 +732,128 @@ packages:
     resolution: {integrity: sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@rollup/rollup-android-arm-eabi@4.55.1':
-    resolution: {integrity: sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==}
+  '@rollup/rollup-android-arm-eabi@4.55.2':
+    resolution: {integrity: sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.55.1':
-    resolution: {integrity: sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==}
+  '@rollup/rollup-android-arm64@4.55.2':
+    resolution: {integrity: sha512-eXBg7ibkNUZ+sTwbFiDKou0BAckeV6kIigK7y5Ko4mB/5A1KLhuzEKovsmfvsL8mQorkoincMFGnQuIT92SKqA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.55.1':
-    resolution: {integrity: sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==}
+  '@rollup/rollup-darwin-arm64@4.55.2':
+    resolution: {integrity: sha512-UCbaTklREjrc5U47ypLulAgg4njaqfOVLU18VrCrI+6E5MQjuG0lSWaqLlAJwsD7NpFV249XgB0Bi37Zh5Sz4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.55.1':
-    resolution: {integrity: sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==}
+  '@rollup/rollup-darwin-x64@4.55.2':
+    resolution: {integrity: sha512-dP67MA0cCMHFT2g5XyjtpVOtp7y4UyUxN3dhLdt11at5cPKnSm4lY+EhwNvDXIMzAMIo2KU+mc9wxaAQJTn7sQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.55.1':
-    resolution: {integrity: sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==}
+  '@rollup/rollup-freebsd-arm64@4.55.2':
+    resolution: {integrity: sha512-WDUPLUwfYV9G1yxNRJdXcvISW15mpvod1Wv3ok+Ws93w1HjIVmCIFxsG2DquO+3usMNCpJQ0wqO+3GhFdl6Fow==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.55.1':
-    resolution: {integrity: sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==}
+  '@rollup/rollup-freebsd-x64@4.55.2':
+    resolution: {integrity: sha512-Ng95wtHVEulRwn7R0tMrlUuiLVL/HXA8Lt/MYVpy88+s5ikpntzZba1qEulTuPnPIZuOPcW9wNEiqvZxZmgmqQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
-    resolution: {integrity: sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.2':
+    resolution: {integrity: sha512-AEXMESUDWWGqD6LwO/HkqCZgUE1VCJ1OhbvYGsfqX2Y6w5quSXuyoy/Fg3nRqiwro+cJYFxiw5v4kB2ZDLhxrw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
-    resolution: {integrity: sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==}
+  '@rollup/rollup-linux-arm-musleabihf@4.55.2':
+    resolution: {integrity: sha512-ZV7EljjBDwBBBSv570VWj0hiNTdHt9uGznDtznBB4Caj3ch5rgD4I2K1GQrtbvJ/QiB+663lLgOdcADMNVC29Q==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.1':
-    resolution: {integrity: sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.55.2':
+    resolution: {integrity: sha512-uvjwc8NtQVPAJtq4Tt7Q49FOodjfbf6NpqXyW/rjXoV+iZ3EJAHLNAnKT5UJBc6ffQVgmXTUL2ifYiLABlGFqA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.55.1':
-    resolution: {integrity: sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==}
+  '@rollup/rollup-linux-arm64-musl@4.55.2':
+    resolution: {integrity: sha512-s3KoWVNnye9mm/2WpOZ3JeUiediUVw6AvY/H7jNA6qgKA2V2aM25lMkVarTDfiicn/DLq3O0a81jncXszoyCFA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.1':
-    resolution: {integrity: sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==}
+  '@rollup/rollup-linux-loong64-gnu@4.55.2':
+    resolution: {integrity: sha512-gi21faacK+J8aVSyAUptML9VQN26JRxe484IbF+h3hpG+sNVoMXPduhREz2CcYr5my0NE3MjVvQ5bMKX71pfVA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-loong64-musl@4.55.1':
-    resolution: {integrity: sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==}
+  '@rollup/rollup-linux-loong64-musl@4.55.2':
+    resolution: {integrity: sha512-qSlWiXnVaS/ceqXNfnoFZh4IiCA0EwvCivivTGbEu1qv2o+WTHpn1zNmCTAoOG5QaVr2/yhCoLScQtc/7RxshA==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
-    resolution: {integrity: sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==}
+  '@rollup/rollup-linux-ppc64-gnu@4.55.2':
+    resolution: {integrity: sha512-rPyuLFNoF1B0+wolH277E780NUKf+KoEDb3OyoLbAO18BbeKi++YN6gC/zuJoPPDlQRL3fIxHxCxVEWiem2yXw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.1':
-    resolution: {integrity: sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==}
+  '@rollup/rollup-linux-ppc64-musl@4.55.2':
+    resolution: {integrity: sha512-g+0ZLMook31iWV4PvqKU0i9E78gaZgYpSrYPed/4Bu+nGTgfOPtfs1h11tSSRPXSjC5EzLTjV/1A7L2Vr8pJoQ==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
-    resolution: {integrity: sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.55.2':
+    resolution: {integrity: sha512-i+sGeRGsjKZcQRh3BRfpLsM3LX3bi4AoEVqmGDyc50L6KfYsN45wVCSz70iQMwPWr3E5opSiLOwsC9WB4/1pqg==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.1':
-    resolution: {integrity: sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==}
+  '@rollup/rollup-linux-riscv64-musl@4.55.2':
+    resolution: {integrity: sha512-C1vLcKc4MfFV6I0aWsC7B2Y9QcsiEcvKkfxprwkPfLaN8hQf0/fKHwSF2lcYzA9g4imqnhic729VB9Fo70HO3Q==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.1':
-    resolution: {integrity: sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==}
+  '@rollup/rollup-linux-s390x-gnu@4.55.2':
+    resolution: {integrity: sha512-68gHUK/howpQjh7g7hlD9DvTTt4sNLp1Bb+Yzw2Ki0xvscm2cOdCLZNJNhd2jW8lsTPrHAHuF751BygifW4bkQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.55.1':
-    resolution: {integrity: sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==}
+  '@rollup/rollup-linux-x64-gnu@4.55.2':
+    resolution: {integrity: sha512-1e30XAuaBP1MAizaOBApsgeGZge2/Byd6wV4a8oa6jPdHELbRHBiw7wvo4dp7Ie2PE8TZT4pj9RLGZv9N4qwlw==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.55.1':
-    resolution: {integrity: sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==}
+  '@rollup/rollup-linux-x64-musl@4.55.2':
+    resolution: {integrity: sha512-4BJucJBGbuGnH6q7kpPqGJGzZnYrpAzRd60HQSt3OpX/6/YVgSsJnNzR8Ot74io50SeVT4CtCWe/RYIAymFPwA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-openbsd-x64@4.55.1':
-    resolution: {integrity: sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==}
+  '@rollup/rollup-openbsd-x64@4.55.2':
+    resolution: {integrity: sha512-cT2MmXySMo58ENv8p6/O6wI/h/gLnD3D6JoajwXFZH6X9jz4hARqUhWpGuQhOgLNXscfZYRQMJvZDtWNzMAIDw==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.55.1':
-    resolution: {integrity: sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==}
+  '@rollup/rollup-openharmony-arm64@4.55.2':
+    resolution: {integrity: sha512-sZnyUgGkuzIXaK3jNMPmUIyJrxu/PjmATQrocpGA1WbCPX8H5tfGgRSuYtqBYAvLuIGp8SPRb1O4d1Fkb5fXaQ==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.1':
-    resolution: {integrity: sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==}
+  '@rollup/rollup-win32-arm64-msvc@4.55.2':
+    resolution: {integrity: sha512-sDpFbenhmWjNcEbBcoTV0PWvW5rPJFvu+P7XoTY0YLGRupgLbFY0XPfwIbJOObzO7QgkRDANh65RjhPmgSaAjQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.1':
-    resolution: {integrity: sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==}
+  '@rollup/rollup-win32-ia32-msvc@4.55.2':
+    resolution: {integrity: sha512-GvJ03TqqaweWCigtKQVBErw2bEhu1tyfNQbarwr94wCGnczA9HF8wqEe3U/Lfu6EdeNP0p6R+APeHVwEqVxpUQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.55.1':
-    resolution: {integrity: sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==}
+  '@rollup/rollup-win32-x64-gnu@4.55.2':
+    resolution: {integrity: sha512-KvXsBvp13oZz9JGe5NYS7FNizLe99Ny+W8ETsuCyjXiKdiGrcz2/J/N8qxZ/RSwivqjQguug07NLHqrIHrqfYw==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.55.1':
-    resolution: {integrity: sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==}
+  '@rollup/rollup-win32-x64-msvc@4.55.2':
+    resolution: {integrity: sha512-xNO+fksQhsAckRtDSPWaMeT1uIM+JrDRXlerpnWNXhn1TdB3YZ6uKBMBTKP0eX9XtYEP978hHk1f8332i2AW8Q==}
     cpu: [x64]
     os: [win32]
 
@@ -910,8 +913,8 @@ packages:
   '@types/node@17.0.45':
     resolution: {integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==}
 
-  '@types/node@25.0.8':
-    resolution: {integrity: sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==}
+  '@types/node@25.0.9':
+    resolution: {integrity: sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw==}
 
   '@types/picomatch@4.0.2':
     resolution: {integrity: sha512-qHHxQ+P9PysNEGbALT8f8YOSHW0KJu6l2xU8DYY0fu/EmGxXdVnuTLvFUvBgPJMSqXq29SYHveejeAha+4AYgA==}
@@ -932,17 +935,17 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
-  '@vue/compiler-core@3.5.26':
-    resolution: {integrity: sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==}
+  '@vue/compiler-core@3.5.27':
+    resolution: {integrity: sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==}
 
-  '@vue/compiler-dom@3.5.26':
-    resolution: {integrity: sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==}
+  '@vue/compiler-dom@3.5.27':
+    resolution: {integrity: sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==}
 
-  '@vue/compiler-sfc@3.5.26':
-    resolution: {integrity: sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==}
+  '@vue/compiler-sfc@3.5.27':
+    resolution: {integrity: sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==}
 
-  '@vue/compiler-ssr@3.5.26':
-    resolution: {integrity: sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==}
+  '@vue/compiler-ssr@3.5.27':
+    resolution: {integrity: sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -965,22 +968,22 @@ packages:
   '@vue/devtools-shared@8.0.5':
     resolution: {integrity: sha512-bRLn6/spxpmgLk+iwOrR29KrYnJjG9DGpHGkDFG82UM21ZpJ39ztUT9OXX3g+usW7/b2z+h46I9ZiYyB07XMXg==}
 
-  '@vue/reactivity@3.5.26':
-    resolution: {integrity: sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==}
+  '@vue/reactivity@3.5.27':
+    resolution: {integrity: sha512-vvorxn2KXfJ0nBEnj4GYshSgsyMNFnIQah/wczXlsNXt+ijhugmW+PpJ2cNPe4V6jpnBcs0MhCODKllWG+nvoQ==}
 
-  '@vue/runtime-core@3.5.26':
-    resolution: {integrity: sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==}
+  '@vue/runtime-core@3.5.27':
+    resolution: {integrity: sha512-fxVuX/fzgzeMPn/CLQecWeDIFNt3gQVhxM0rW02Tvp/YmZfXQgcTXlakq7IMutuZ/+Ogbn+K0oct9J3JZfyk3A==}
 
-  '@vue/runtime-dom@3.5.26':
-    resolution: {integrity: sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==}
+  '@vue/runtime-dom@3.5.27':
+    resolution: {integrity: sha512-/QnLslQgYqSJ5aUmb5F0z0caZPGHRB8LEAQ1s81vHFM5CBfnun63rxhvE/scVb/j3TbBuoZwkJyiLCkBluMpeg==}
 
-  '@vue/server-renderer@3.5.26':
-    resolution: {integrity: sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==}
+  '@vue/server-renderer@3.5.27':
+    resolution: {integrity: sha512-qOz/5thjeP1vAFc4+BY3Nr6wxyLhpeQgAE/8dDtKo6a6xdk+L4W46HDZgNmLOBUDEkFXV3G7pRiUqxjX0/2zWA==}
     peerDependencies:
-      vue: 3.5.26
+      vue: 3.5.27
 
-  '@vue/shared@3.5.26':
-    resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
+  '@vue/shared@3.5.27':
+    resolution: {integrity: sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==}
 
   '@vuepress/bundler-vite@2.0.0-rc.18':
     resolution: {integrity: sha512-Q+OUul4OLIS4OLuKqIlmJKHhW5Edt5i6fVY6infgGhb4tUQt3z37DjCUtvbMikb05Va9YqtTAGt2eCWOk7eGPw==}
@@ -1208,8 +1211,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.9.14:
-    resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
+  baseline-browser-mapping@2.9.15:
+    resolution: {integrity: sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==}
     hasBin: true
 
   birpc@2.9.0:
@@ -1240,8 +1243,8 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  caniuse-lite@1.0.30001764:
-    resolution: {integrity: sha512-9JGuzl2M+vPL+pz70gtMF9sHdMFbY9FJaQBi186cHKH3pSzDvzoUJUPV6fqiKIMyXbud9ZLg4F3Yza1vJ1+93g==}
+  caniuse-lite@1.0.30001765:
+    resolution: {integrity: sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1775,8 +1778,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup@4.55.1:
-    resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
+  rollup@4.55.2:
+    resolution: {integrity: sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2139,8 +2142,8 @@ packages:
     peerDependencies:
       vue: ^3.5.0
 
-  vue@3.5.26:
-    resolution: {integrity: sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==}
+  vue@3.5.27:
+    resolution: {integrity: sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
@@ -2655,79 +2658,79 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.4
     optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.55.1':
+  '@rollup/rollup-android-arm-eabi@4.55.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.55.1':
+  '@rollup/rollup-android-arm64@4.55.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.55.1':
+  '@rollup/rollup-darwin-arm64@4.55.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.55.1':
+  '@rollup/rollup-darwin-x64@4.55.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.55.1':
+  '@rollup/rollup-freebsd-arm64@4.55.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.55.1':
+  '@rollup/rollup-freebsd-x64@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.55.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.55.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.55.1':
+  '@rollup/rollup-linux-arm64-gnu@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.55.1':
+  '@rollup/rollup-linux-arm64-musl@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.55.1':
+  '@rollup/rollup-linux-loong64-gnu@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.55.1':
+  '@rollup/rollup-linux-loong64-musl@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.55.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.55.1':
+  '@rollup/rollup-linux-ppc64-musl@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.55.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.55.1':
+  '@rollup/rollup-linux-riscv64-musl@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.55.1':
+  '@rollup/rollup-linux-s390x-gnu@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.55.1':
+  '@rollup/rollup-linux-x64-gnu@4.55.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.55.1':
+  '@rollup/rollup-linux-x64-musl@4.55.2':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.55.1':
+  '@rollup/rollup-openbsd-x64@4.55.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.55.1':
+  '@rollup/rollup-openharmony-arm64@4.55.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.55.1':
+  '@rollup/rollup-win32-arm64-msvc@4.55.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.55.1':
+  '@rollup/rollup-win32-ia32-msvc@4.55.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.55.1':
+  '@rollup/rollup-win32-x64-gnu@4.55.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.55.1':
+  '@rollup/rollup-win32-x64-msvc@4.55.2':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -2745,13 +2748,13 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 25.0.8
+      '@types/node': 25.0.9
 
   '@types/hash-sum@1.0.2': {}
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 25.0.8
+      '@types/node': 25.0.9
 
   '@types/linkify-it@3.0.5': {}
 
@@ -2783,7 +2786,7 @@ snapshots:
 
   '@types/node@17.0.45': {}
 
-  '@types/node@25.0.8':
+  '@types/node@25.0.9':
     dependencies:
       undici-types: 7.16.0
 
@@ -2797,40 +2800,40 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)':
     dependencies:
-      vite: 5.4.21(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2)
-      vue: 3.5.26
+      vite: 5.4.21(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2)
+      vue: 3.5.27
 
-  '@vue/compiler-core@3.5.26':
+  '@vue/compiler-core@3.5.27':
     dependencies:
       '@babel/parser': 7.28.6
-      '@vue/shared': 3.5.26
+      '@vue/shared': 3.5.27
       entities: 7.0.0
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  '@vue/compiler-dom@3.5.26':
+  '@vue/compiler-dom@3.5.27':
     dependencies:
-      '@vue/compiler-core': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/compiler-core': 3.5.27
+      '@vue/shared': 3.5.27
 
-  '@vue/compiler-sfc@3.5.26':
+  '@vue/compiler-sfc@3.5.27':
     dependencies:
       '@babel/parser': 7.28.6
-      '@vue/compiler-core': 3.5.26
-      '@vue/compiler-dom': 3.5.26
-      '@vue/compiler-ssr': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/compiler-core': 3.5.27
+      '@vue/compiler-dom': 3.5.27
+      '@vue/compiler-ssr': 3.5.27
+      '@vue/shared': 3.5.27
       estree-walker: 2.0.2
       magic-string: 0.30.21
       postcss: 8.5.6
       source-map-js: 1.2.1
 
-  '@vue/compiler-ssr@3.5.26':
+  '@vue/compiler-ssr@3.5.27':
     dependencies:
-      '@vue/compiler-dom': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/compiler-dom': 3.5.27
+      '@vue/shared': 3.5.27
 
   '@vue/devtools-api@6.6.4': {}
 
@@ -2870,33 +2873,33 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/reactivity@3.5.26':
+  '@vue/reactivity@3.5.27':
     dependencies:
-      '@vue/shared': 3.5.26
+      '@vue/shared': 3.5.27
 
-  '@vue/runtime-core@3.5.26':
+  '@vue/runtime-core@3.5.27':
     dependencies:
-      '@vue/reactivity': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/reactivity': 3.5.27
+      '@vue/shared': 3.5.27
 
-  '@vue/runtime-dom@3.5.26':
+  '@vue/runtime-dom@3.5.27':
     dependencies:
-      '@vue/reactivity': 3.5.26
-      '@vue/runtime-core': 3.5.26
-      '@vue/shared': 3.5.26
+      '@vue/reactivity': 3.5.27
+      '@vue/runtime-core': 3.5.27
+      '@vue/shared': 3.5.27
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.26(vue@3.5.26)':
+  '@vue/server-renderer@3.5.27(vue@3.5.27)':
     dependencies:
-      '@vue/compiler-ssr': 3.5.26
-      '@vue/shared': 3.5.26
-      vue: 3.5.26
+      '@vue/compiler-ssr': 3.5.27
+      '@vue/shared': 3.5.27
+      vue: 3.5.27
 
-  '@vue/shared@3.5.26': {}
+  '@vue/shared@3.5.27': {}
 
-  '@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2)':
+  '@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2)':
     dependencies:
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
       '@vuepress/bundlerutils': 2.0.0-rc.18
       '@vuepress/client': 2.0.0-rc.18
       '@vuepress/core': 2.0.0-rc.18
@@ -2906,10 +2909,10 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       postcss: 8.5.6
       postcss-load-config: 6.0.1(postcss@8.5.6)
-      rollup: 4.55.1
-      vite: 5.4.21(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2)
-      vue: 3.5.26
-      vue-router: 4.6.4(vue@3.5.26)
+      rollup: 4.55.2
+      vite: 5.4.21(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2)
+      vue: 3.5.27
+      vue-router: 4.6.4(vue@3.5.27)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2931,8 +2934,8 @@ snapshots:
       '@vuepress/core': 2.0.0-rc.18
       '@vuepress/shared': 2.0.0-rc.18
       '@vuepress/utils': 2.0.0-rc.18
-      vue: 3.5.26
-      vue-router: 4.6.4(vue@3.5.26)
+      vue: 3.5.27
+      vue-router: 4.6.4(vue@3.5.27)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2954,9 +2957,9 @@ snapshots:
     dependencies:
       '@vue/devtools-api': 6.6.4
       '@vuepress/shared': 2.0.0-rc.0
-      '@vueuse/core': 10.11.1(vue@3.5.26)
-      vue: 3.5.26
-      vue-router: 4.6.4(vue@3.5.26)
+      '@vueuse/core': 10.11.1(vue@3.5.27)
+      vue: 3.5.27
+      vue-router: 4.6.4(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
@@ -2965,8 +2968,8 @@ snapshots:
     dependencies:
       '@vue/devtools-api': 7.7.9
       '@vuepress/shared': 2.0.0-rc.18
-      vue: 3.5.26
-      vue-router: 4.6.4(vue@3.5.26)
+      vue: 3.5.27
+      vue-router: 4.6.4(vue@3.5.27)
     transitivePeerDependencies:
       - typescript
 
@@ -2975,8 +2978,8 @@ snapshots:
       '@vue/devtools-api': 8.0.5
       '@vue/devtools-kit': 8.0.5
       '@vuepress/shared': 2.0.0-rc.26
-      vue: 3.5.26
-      vue-router: 4.6.4(vue@3.5.26)
+      vue: 3.5.27
+      vue-router: 4.6.4(vue@3.5.27)
     transitivePeerDependencies:
       - typescript
 
@@ -2986,7 +2989,7 @@ snapshots:
       '@vuepress/markdown': 2.0.0-rc.0
       '@vuepress/shared': 2.0.0-rc.0
       '@vuepress/utils': 2.0.0-rc.0
-      vue: 3.5.26
+      vue: 3.5.27
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
@@ -2998,7 +3001,7 @@ snapshots:
       '@vuepress/markdown': 2.0.0-rc.18
       '@vuepress/shared': 2.0.0-rc.18
       '@vuepress/utils': 2.0.0-rc.18
-      vue: 3.5.26
+      vue: 3.5.27
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3009,41 +3012,41 @@ snapshots:
       '@vuepress/markdown': 2.0.0-rc.26
       '@vuepress/shared': 2.0.0-rc.26
       '@vuepress/utils': 2.0.0-rc.26
-      vue: 3.5.26
+      vue: 3.5.27
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@vuepress/helper@2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/helper@2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vue/shared': 3.5.26
-      '@vueuse/core': 14.1.0(vue@3.5.26)
+      '@vue/shared': 3.5.27
+      '@vueuse/core': 14.1.0(vue@3.5.27)
       cheerio: 1.1.2
       fflate: 0.8.2
       gray-matter: 4.0.3
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/helper@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/helper@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vue/shared': 3.5.26
-      '@vueuse/core': 11.3.0(vue@3.5.26)
+      '@vue/shared': 3.5.27
+      '@vueuse/core': 11.3.0(vue@3.5.27)
       cheerio: 1.0.0
       fflate: 0.8.2
       gray-matter: 4.0.3
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/highlighter-helper@2.0.0-rc.56(@vueuse/core@11.3.0(vue@3.5.26))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/highlighter-helper@2.0.0-rc.56(@vueuse/core@11.3.0(vue@3.5.27))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     optionalDependencies:
-      '@vueuse/core': 11.3.0(vue@3.5.26)
+      '@vueuse/core': 11.3.0(vue@3.5.27)
 
   '@vuepress/markdown@2.0.0-rc.0':
     dependencies:
@@ -3108,40 +3111,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vuepress/plugin-active-header-links@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-active-header-links@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vueuse/core': 11.3.0(vue@3.5.26)
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vueuse/core': 11.3.0(vue@3.5.27)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-back-to-top@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-back-to-top@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vueuse/core': 11.3.0(vue@3.5.26)
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vueuse/core': 11.3.0(vue@3.5.27)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-copy-code@2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-copy-code@2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vueuse/core': 14.1.0(vue@3.5.26)
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vueuse/core': 14.1.0(vue@3.5.27)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/plugin-copy-code@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-copy-code@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vueuse/core': 11.3.0(vue@3.5.26)
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vueuse/core': 11.3.0(vue@3.5.27)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
@@ -3153,129 +3156,129 @@ snapshots:
       '@vuepress/markdown': 2.0.0-rc.0
       '@vuepress/shared': 2.0.0-rc.0
       '@vuepress/utils': 2.0.0-rc.0
-      vue: 3.5.26
+      vue: 3.5.27
     transitivePeerDependencies:
       - '@vue/composition-api'
       - supports-color
       - typescript
 
-  '@vuepress/plugin-git@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-git@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
       execa: 9.6.1
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
 
-  '@vuepress/plugin-links-check@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-links-check@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-markdown-hint@2.0.0-rc.60(markdown-it@14.1.0)(vue@3.5.26)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-markdown-hint@2.0.0-rc.60(markdown-it@14.1.0)(vue@3.5.27)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
       '@mdit/plugin-alert': 0.13.1(markdown-it@14.1.0)
       '@mdit/plugin-container': 0.13.1(markdown-it@14.1.0)
       '@types/markdown-it': 14.1.2
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vueuse/core': 11.3.0(vue@3.5.26)
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vueuse/core': 11.3.0(vue@3.5.27)
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - markdown-it
       - typescript
       - vue
 
-  '@vuepress/plugin-markdown-tab@2.0.0-rc.60(markdown-it@14.1.0)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-markdown-tab@2.0.0-rc.60(markdown-it@14.1.0)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
       '@mdit/plugin-tab': 0.13.2(markdown-it@14.1.0)
       '@types/markdown-it': 14.1.2
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vueuse/core': 11.3.0(vue@3.5.26)
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vueuse/core': 11.3.0(vue@3.5.27)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - markdown-it
       - typescript
 
-  '@vuepress/plugin-medium-zoom@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-medium-zoom@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       medium-zoom: 1.1.0
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-nprogress@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-nprogress@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-palette@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-palette@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       chokidar: 4.0.3
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-prismjs@2.0.0-rc.60(@vueuse/core@11.3.0(vue@3.5.26))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-prismjs@2.0.0-rc.60(@vueuse/core@11.3.0(vue@3.5.27))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/highlighter-helper': 2.0.0-rc.56(@vueuse/core@11.3.0(vue@3.5.26))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/highlighter-helper': 2.0.0-rc.56(@vueuse/core@11.3.0(vue@3.5.27))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       prismjs: 1.30.0
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - '@vueuse/core'
       - typescript
 
-  '@vuepress/plugin-search@2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-search@2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+      '@vuepress/helper': 2.0.0-rc.121(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       chokidar: 4.0.3
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - typescript
 
-  '@vuepress/plugin-seo@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-seo@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-sitemap@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-sitemap@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
       sitemap: 8.0.2
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - typescript
 
-  '@vuepress/plugin-theme-data@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/plugin-theme-data@2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
       '@vue/devtools-api': 7.7.9
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     transitivePeerDependencies:
       - typescript
 
   '@vuepress/shared@2.0.0-rc.0':
     dependencies:
       '@mdit-vue/types': 1.0.0
-      '@vue/shared': 3.5.26
+      '@vue/shared': 3.5.27
 
   '@vuepress/shared@2.0.0-rc.18':
     dependencies:
@@ -3285,26 +3288,26 @@ snapshots:
     dependencies:
       '@mdit-vue/types': 3.0.2
 
-  '@vuepress/theme-default@2.0.0-rc.60(markdown-it@14.1.0)(sass-embedded@1.97.2)(sass@1.97.2)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))':
+  '@vuepress/theme-default@2.0.0-rc.60(markdown-it@14.1.0)(sass-embedded@1.97.2)(sass@1.97.2)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))':
     dependencies:
-      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-active-header-links': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-back-to-top': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-copy-code': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-git': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-links-check': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-markdown-hint': 2.0.0-rc.60(markdown-it@14.1.0)(vue@3.5.26)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-markdown-tab': 2.0.0-rc.60(markdown-it@14.1.0)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-medium-zoom': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-nprogress': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-palette': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-prismjs': 2.0.0-rc.60(@vueuse/core@11.3.0(vue@3.5.26))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-seo': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-sitemap': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vuepress/plugin-theme-data': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26))
-      '@vueuse/core': 11.3.0(vue@3.5.26)
-      vue: 3.5.26
-      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26)
+      '@vuepress/helper': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-active-header-links': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-back-to-top': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-copy-code': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-git': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-links-check': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-markdown-hint': 2.0.0-rc.60(markdown-it@14.1.0)(vue@3.5.27)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-markdown-tab': 2.0.0-rc.60(markdown-it@14.1.0)(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-medium-zoom': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-nprogress': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-palette': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-prismjs': 2.0.0-rc.60(@vueuse/core@11.3.0(vue@3.5.27))(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-seo': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-sitemap': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vuepress/plugin-theme-data': 2.0.0-rc.60(vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27))
+      '@vueuse/core': 11.3.0(vue@3.5.27)
+      vue: 3.5.27
+      vuepress: 2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27)
     optionalDependencies:
       sass: 1.97.2
       sass-embedded: 1.97.2
@@ -3363,32 +3366,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vueuse/core@10.11.1(vue@3.5.26)':
+  '@vueuse/core@10.11.1(vue@3.5.27)':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 10.11.1
-      '@vueuse/shared': 10.11.1(vue@3.5.26)
-      vue-demi: 0.14.10(vue@3.5.26)
+      '@vueuse/shared': 10.11.1(vue@3.5.27)
+      vue-demi: 0.14.10(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@11.3.0(vue@3.5.26)':
+  '@vueuse/core@11.3.0(vue@3.5.27)':
     dependencies:
       '@types/web-bluetooth': 0.0.20
       '@vueuse/metadata': 11.3.0
-      '@vueuse/shared': 11.3.0(vue@3.5.26)
-      vue-demi: 0.14.10(vue@3.5.26)
+      '@vueuse/shared': 11.3.0(vue@3.5.27)
+      vue-demi: 0.14.10(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/core@14.1.0(vue@3.5.26)':
+  '@vueuse/core@14.1.0(vue@3.5.27)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.1.0
-      '@vueuse/shared': 14.1.0(vue@3.5.26)
-      vue: 3.5.26
+      '@vueuse/shared': 14.1.0(vue@3.5.27)
+      vue: 3.5.27
 
   '@vueuse/metadata@10.11.1': {}
 
@@ -3396,23 +3399,23 @@ snapshots:
 
   '@vueuse/metadata@14.1.0': {}
 
-  '@vueuse/shared@10.11.1(vue@3.5.26)':
+  '@vueuse/shared@10.11.1(vue@3.5.27)':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.26)
+      vue-demi: 0.14.10(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@11.3.0(vue@3.5.26)':
+  '@vueuse/shared@11.3.0(vue@3.5.27)':
     dependencies:
-      vue-demi: 0.14.10(vue@3.5.26)
+      vue-demi: 0.14.10(vue@3.5.27)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
 
-  '@vueuse/shared@14.1.0(vue@3.5.26)':
+  '@vueuse/shared@14.1.0(vue@3.5.27)':
     dependencies:
-      vue: 3.5.26
+      vue: 3.5.27
 
   ansi-regex@6.2.2: {}
 
@@ -3427,7 +3430,7 @@ snapshots:
   autoprefixer@10.4.23(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
-      caniuse-lite: 1.0.30001764
+      caniuse-lite: 1.0.30001765
       fraction.js: 5.3.4
       picocolors: 1.1.1
       postcss: 8.5.6
@@ -3435,7 +3438,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.9.14: {}
+  baseline-browser-mapping@2.9.15: {}
 
   birpc@2.9.0: {}
 
@@ -3453,8 +3456,8 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.9.14
-      caniuse-lite: 1.0.30001764
+      baseline-browser-mapping: 2.9.15
+      caniuse-lite: 1.0.30001765
       electron-to-chromium: 1.5.267
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -3468,7 +3471,7 @@ snapshots:
 
   cac@6.7.14: {}
 
-  caniuse-lite@1.0.30001764: {}
+  caniuse-lite@1.0.30001765: {}
 
   chalk@5.6.2: {}
 
@@ -4061,35 +4064,35 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup@4.55.1:
+  rollup@4.55.2:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.55.1
-      '@rollup/rollup-android-arm64': 4.55.1
-      '@rollup/rollup-darwin-arm64': 4.55.1
-      '@rollup/rollup-darwin-x64': 4.55.1
-      '@rollup/rollup-freebsd-arm64': 4.55.1
-      '@rollup/rollup-freebsd-x64': 4.55.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.55.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.55.1
-      '@rollup/rollup-linux-arm64-gnu': 4.55.1
-      '@rollup/rollup-linux-arm64-musl': 4.55.1
-      '@rollup/rollup-linux-loong64-gnu': 4.55.1
-      '@rollup/rollup-linux-loong64-musl': 4.55.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.55.1
-      '@rollup/rollup-linux-ppc64-musl': 4.55.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.55.1
-      '@rollup/rollup-linux-riscv64-musl': 4.55.1
-      '@rollup/rollup-linux-s390x-gnu': 4.55.1
-      '@rollup/rollup-linux-x64-gnu': 4.55.1
-      '@rollup/rollup-linux-x64-musl': 4.55.1
-      '@rollup/rollup-openbsd-x64': 4.55.1
-      '@rollup/rollup-openharmony-arm64': 4.55.1
-      '@rollup/rollup-win32-arm64-msvc': 4.55.1
-      '@rollup/rollup-win32-ia32-msvc': 4.55.1
-      '@rollup/rollup-win32-x64-gnu': 4.55.1
-      '@rollup/rollup-win32-x64-msvc': 4.55.1
+      '@rollup/rollup-android-arm-eabi': 4.55.2
+      '@rollup/rollup-android-arm64': 4.55.2
+      '@rollup/rollup-darwin-arm64': 4.55.2
+      '@rollup/rollup-darwin-x64': 4.55.2
+      '@rollup/rollup-freebsd-arm64': 4.55.2
+      '@rollup/rollup-freebsd-x64': 4.55.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.55.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.55.2
+      '@rollup/rollup-linux-arm64-gnu': 4.55.2
+      '@rollup/rollup-linux-arm64-musl': 4.55.2
+      '@rollup/rollup-linux-loong64-gnu': 4.55.2
+      '@rollup/rollup-linux-loong64-musl': 4.55.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.55.2
+      '@rollup/rollup-linux-ppc64-musl': 4.55.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.55.2
+      '@rollup/rollup-linux-riscv64-musl': 4.55.2
+      '@rollup/rollup-linux-s390x-gnu': 4.55.2
+      '@rollup/rollup-linux-x64-gnu': 4.55.2
+      '@rollup/rollup-linux-x64-musl': 4.55.2
+      '@rollup/rollup-openbsd-x64': 4.55.2
+      '@rollup/rollup-openharmony-arm64': 4.55.2
+      '@rollup/rollup-win32-arm64-msvc': 4.55.2
+      '@rollup/rollup-win32-ia32-msvc': 4.55.2
+      '@rollup/rollup-win32-x64-gnu': 4.55.2
+      '@rollup/rollup-win32-x64-msvc': 4.55.2
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -4319,49 +4322,49 @@ snapshots:
 
   varint@6.0.0: {}
 
-  vite@5.4.21(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2):
+  vite@5.4.21(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
-      rollup: 4.55.1
+      rollup: 4.55.2
     optionalDependencies:
-      '@types/node': 25.0.8
+      '@types/node': 25.0.9
       fsevents: 2.3.3
       sass: 1.97.2
       sass-embedded: 1.97.2
 
-  vite@7.3.1(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2):
+  vite@7.3.1(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.55.1
+      rollup: 4.55.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.0.8
+      '@types/node': 25.0.9
       fsevents: 2.3.3
       sass: 1.97.2
       sass-embedded: 1.97.2
 
-  vue-demi@0.14.10(vue@3.5.26):
+  vue-demi@0.14.10(vue@3.5.27):
     dependencies:
-      vue: 3.5.26
+      vue: 3.5.27
 
-  vue-router@4.6.4(vue@3.5.26):
+  vue-router@4.6.4(vue@3.5.27):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.26
+      vue: 3.5.27
 
-  vue@3.5.26:
+  vue@3.5.27:
     dependencies:
-      '@vue/compiler-dom': 3.5.26
-      '@vue/compiler-sfc': 3.5.26
-      '@vue/runtime-dom': 3.5.26
-      '@vue/server-renderer': 3.5.26(vue@3.5.26)
-      '@vue/shared': 3.5.26
+      '@vue/compiler-dom': 3.5.27
+      '@vue/compiler-sfc': 3.5.27
+      '@vue/runtime-dom': 3.5.27
+      '@vue/server-renderer': 3.5.27(vue@3.5.27)
+      '@vue/shared': 3.5.27
 
-  vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.26):
+  vuepress@2.0.0-rc.26(@vuepress/bundler-vite@2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2))(vue@3.5.27):
     dependencies:
       '@vuepress/cli': 2.0.0-rc.26
       '@vuepress/client': 2.0.0-rc.26
@@ -4369,9 +4372,9 @@ snapshots:
       '@vuepress/markdown': 2.0.0-rc.26
       '@vuepress/shared': 2.0.0-rc.26
       '@vuepress/utils': 2.0.0-rc.26
-      vue: 3.5.26
+      vue: 3.5.27
     optionalDependencies:
-      '@vuepress/bundler-vite': 2.0.0-rc.18(@types/node@25.0.8)(sass-embedded@1.97.2)(sass@1.97.2)
+      '@vuepress/bundler-vite': 2.0.0-rc.18(@types/node@25.0.9)(sass-embedded@1.97.2)(sass@1.97.2)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
## Summary
This PR fixes a pnpm docs:build failure due to missing the vue-route module. This module has been added and is required for handling the redirect to the en-US or fr-CA homepage depending on selected locale. 