### PR TITLE
fix: updated Manuscript Overview English text

### DIFF
--- a/docs/en/publication-process/manuscript-overview.md
+++ b/docs/en/publication-process/manuscript-overview.md
@@ -2,61 +2,67 @@
 lang: en-US
 title: Publishing Process Overview
 description: Overview of manuscript types and workflows in the Open Science Portal
+sidebarDepth: 1
 ---
 
-The Open Science Portal supports three types of manuscript record forms, each with their own workflow and requirements. This section will help you understand which type applies to your situation and guide you through the appropriate process.
+The Open Science Portal supports two main types of publications, each with its own process and requirements. This section will help you understand which type applies to your situation and guide you through the appropriate process.
 
-## Publication Types
+## Types of Publications
 
 ### DFO Publications
 
-**DFO Publications** are manuscripts that will be published in a DFO Science Series by Fisheries and Oceans Canada. These include:
+**DFO publications** are manuscripts that will be published directly by Fisheries and Oceans Canada. These include:
 
 - DFO Technical Reports
 - DFO Research Documents
 - DFO Advisory Documents
-- Other official DFO Science publications
+- Other official DFO publications
 
-**When to use this workflow:**
+**When to use this process:**
 
-- Your manuscript will be published through DFO's official publication channels
+- Your manuscript will be published through official DFO publication channels
 - DFO is the primary publisher
+- The work was conducted primarily within DFO or funded by DFO
+
+[→ Get started with the DFO Manuscript Record Form](/en/publication-process/manuscript-record-form.md)
 
 ### Third-Party Publications
 
-**Third-Party Publications** are manuscripts that will be published by external publishers such as:
+**Third-party publications** are manuscripts that will be published by external publishers such as:
 
 - Peer-reviewed journals
 - Conference proceedings
 - Book chapters
 - Other non-DFO publications
 
-**When to use this workflow:**
+**When to use this process:**
 
 - Your manuscript will be submitted to an external journal or publisher
 - DFO is not the publisher, but DFO authors or resources are involved
 - The work involves DFO researchers but will be published elsewhere
 
+[→ Get started with the Third-Party Manuscript Record Form](/en/publication-process/manuscript-record-form.md)
+
 ### Preprints
 
-**Preprints** are scientific or technical documents intended for dissemination via a preprint server prior to, or independent of, formal peer-reviewed publication in a journal, book, or conference proceeding.
+**Preprints** are scientific or technical documents intended to be shared via a preprint server before, or independently of, formal peer-reviewed publication in a journal, book, or conference proceedings.
 
-**When to use this workflow:**
+**When to use this process:**
 
-- You intend to publish a manuscript on a preprint server to gather feedback.
+- You intend to post a manuscript on a preprint server to gather feedback.
 
-## Common Workflow Steps
+## Common Process Steps
 
 All publication types share several common steps:
 
-1. **Manuscript Record Creation** - Create and populate the manuscript record form
-2. **Management Review Process** - Submit for review by appropriate managers
-3. **Publication Management** - Track and manage the publication once approved
+1. **Manuscript Record Creation** – Create and complete the Manuscript Record Form
+2. **Management Review Process** – Submit for review by the appropriate managers
+3. **Publication Management** – Track and manage the publication once approved
 
 ## Need Help Deciding?
 
-If you're unsure which publication type applies to your manuscript:
+If you are unsure which publication type applies to your manuscript:
 
-1. Consider who will be the publisher of the work
+1. Consider who will be the publisher of the final work
 2. Review the specific requirements in each section
-3. Contact the [Open Science Portal Support Team](mailto:DFO.OpenScience-ScienceOuverte.MPO@dfo-mpo.gc.ca) for guidance
+3. Contact the [Open Science Portal support team](mailto:DFO.OpenScience-ScienceOuverte.MPO@dfo-mpo.gc.ca) for guidance

--- a/docs/fr/publication-process/manuscript-overview.md
+++ b/docs/fr/publication-process/manuscript-overview.md
@@ -1,7 +1,8 @@
 ---
-lang: fr-FR
+lang: fr-CA
 title: Aperçu des publications
 description: Aperçu des types de publications et des processus dans le Portail de la Science Ouverte
+sidebarDepth: 1
 ---
 
 Le Portail de la Science Ouverte prend en charge deux principaux types de publications, chacun avec son propre processus et ses exigences. Cette section vous aidera à comprendre quel type s'applique à votre situation et vous guidera à travers le processus approprié.


### PR DESCRIPTION
## Summary
This PR updates the text in the English Publishing Process Overview to match content on the French page. Sidebar sub-menu depth has been adjusted to only display Heading 1 and Heading 2 on both the en-US and fr-CA pages.