### PR TITLE
fix(search): correct bad env var calls in search bar

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     env_file:
       - .env
     ports:
-      - "127.0.0.1:${TYPESENSE_PORT:-8108}:8108"
+      - "127.0.0.1:8108:8108"
     volumes:
       - ./typesense-data:/data
     command: > 
@@ -23,7 +23,7 @@ services:
     env_file:
       - .env
     environment:
-      TYPESENSE_HOST: typsense
+      TYPESENSE_HOST: typesense
       TYPESENSE_PORT: "8108"
       TYPESENSE_PROTOCOL: http
     volumes:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -5,6 +5,20 @@ import 'dotenv/config';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+// Check required typesense environment variables
+
+const typesenseSearchApiKey = process.env.TYPESENSE_SEARCH_API_KEY;
+
+if (!typesenseSearchApiKey) {
+  throw new Error('TYPESENSE_SEARCH_API_KEY must be set.');
+}
+
+const typesenseHost = process.env.TYPESENSE_HOST;
+
+if (!typesenseHost) {
+  throw new Error('TYPESENSE_HOST must be set.');
+}
+
 const config: Config = {
   title: 'Open Science Portal User Guide',
   tagline: 'Complete documentation for researchers, authors, and managers',
@@ -88,12 +102,12 @@ const config: Config = {
   typesenseServerConfig: {
     nodes: [
       {
-        host: process.env.TYPESENSE_HOST ?? 'localhost',
-        port: Number(process.env.TYPESENSE_PORT ?? 8108),
-        protocol: process.env.TYPESENSE_PROTOCOL ?? 'http',
+        host: typesenseHost,
+        port: Number(process.env.TYPESENSE_PORT ?? 443),
+        protocol: process.env.TYPESENSE_PROTOCOL ?? 'https',
       },
     ],
-    apiKey: process.env.TYPESENSE_SEARCH_API_KEY ?? '',
+    apiKey: typesenseSearchApiKey,
   },
 
   contextualSearch: true,


### PR DESCRIPTION
## Summary
This PR cleans up the variables used to start the typesense server as well as adds additional checks for required search environment variables. In theory, this PR should get the search bar working.